### PR TITLE
Get rid of textarea resize gripper nub thingy

### DIFF
--- a/main.css
+++ b/main.css
@@ -244,6 +244,7 @@ textarea
     line-height: 160%;
     font-size: 16pt;
     background: none;
+    resize: none;
     }
 button.text, a.text
     {


### PR DESCRIPTION
Y'know, this thingy, in the bottom middle-right corner: 
![image](https://cloud.githubusercontent.com/assets/225809/13423840/3487bc46-df52-11e5-9078-a61843c00453.png)

Since you disabled being able to resize the textarea by dragging the thing.
