### PR TITLE
remember last selected session settings

### DIFF
--- a/js/common.js
+++ b/js/common.js
@@ -10,7 +10,8 @@
     };
 
   $.fn.write_button = function(options){
-    let settings = $.extend({}, defaults, options),
+    let user_settings = JSON.parse(localStorage.getItem('mdwa.settings') || "{}");
+    let settings = $.extend({}, defaults, user_settings, options),
         el = $(this);
 
     el.each(function() {
@@ -66,7 +67,12 @@
       let set_url = function() {
         let limit = $chooser.find("input[type=radio]:checked").val()
         let hardcore = $chooser.find("#hardcore-check")[0].checked ? "&hardcore=true" : "";
-        btn.attr('href', `${url}?limit=${limit}${hardcore}`)
+        btn.attr('href', `${url}?limit=${limit}${hardcore}`);
+        localStorage.setItem('mdwa.settings', JSON.stringify({
+            type: limit.substring(limit.length - 3, limit.length) === "min" ? 'timed' : 'words',
+            limit: parseInt(limit),
+            hardcore: $chooser.find("#hardcore-check")[0].checked
+        }));
       }
       $chooser.find("input").on('change', set_url);
       $chooser.find(".tabs .words").bind('click', function () {


### PR DESCRIPTION
at the moment every time I open the app, it shows the default 5min long session. since I almost always use 500words limit it is kind of annoying to have to change it every time.

but everyone has a different preference so we can't change the default to that, how about remembering what the user selected the last time and have that as default instead? (like we do with the night mode)

P.S. i don't have codekit, so i wasn't sure about how to minify the common.js file, for testing i just copied the unminified version over. if you give me instructions or a free tool to minify it/build the app with i would, otherwise just build it before merging.