### PR TITLE
fixes #20 (fadeOut chooser after delay if hidden=true)

### DIFF
--- a/js/common.js
+++ b/js/common.js
@@ -61,7 +61,20 @@
       `);
       btn.parent().prepend($chooser);
       if (settings.hidden) {
-        btn.on("mouseenter", function() {$chooser.fadeIn();});
+        let chooserExpireTimer = null;
+        let closeChooserAfterDelay = function () {
+            clearTimeout(chooserExpireTimer);
+            chooserExpireTimer = setTimeout(function () {
+                $chooser.fadeOut();
+            }, 5000);
+        };
+        btn.on("mouseenter", function() {
+          $chooser.fadeIn();
+          closeChooserAfterDelay()
+        });
+        $chooser.on("mouseenter mousemove mouseleave", function () {
+            closeChooserAfterDelay()
+        });
       }
       let set_url = function() {
         let limit = $chooser.find("input[type=radio]:checked").val()


### PR DESCRIPTION
a 5sec timer that hides the chooser popup that resets after each interaction starting from the moment user mouseover's the "start again" button.