### PR TITLE
Add a 15 minutes time limit option

### DIFF
--- a/js/common.js
+++ b/js/common.js
@@ -1,7 +1,7 @@
 !function($){
   let defaults = {
     position: "top",
-    time_limits: [3, 5, 10, 20, 30, 60],
+    time_limits: [3, 5, 10, 15, 20, 30, 60],
     word_limits: [75, 150, 250, 500, 1667],
     type: "timed",
     limit: 5,


### PR DESCRIPTION
This pull request adds a 15 minute option to the list of time limits.

Between the 10 minute and the 20 minute option, a middle ground option would be useful.

In my experience using the app, a 10 minute writing session goes by relatively fast, but it's a big jump from there to the next duration of 20 minutes. Hence the proposal for a 15 minute duration to be added.